### PR TITLE
Bugfix/ll 32 null value

### DIFF
--- a/compiler/astClasses/statements/AssignStructProperty.cs
+++ b/compiler/astClasses/statements/AssignStructProperty.cs
@@ -16,7 +16,7 @@ namespace ll.AST
                     throw new ArgumentException($"Type \"{structProp.type.typeName}\" is not compatible with \"{val.type.typeName}\"; On line {line}:{column}");
             }
 
-            if (structProp.type.typeName != val.type.typeName)
+            if (structProp.type.typeName != val.type.typeName && !(structProp.type is RefType && val.type is NullType))
                 throw new ArgumentException($"Type \"{structProp.type.typeName}\" is not compatible with \"{val.type.typeName}\"; On line {line}:{column}");
 
             this.structProp = structProp;

--- a/testGeneratedCode/testCodeGenV1.c
+++ b/testGeneratedCode/testCodeGenV1.c
@@ -149,6 +149,8 @@ long accessSecondInnerStruct(long x);
 
 long accessInnerArray(long x);
 
+long assignNullStructProp();
+
 int failedCount = 0;
 int overallCount = 0;
 
@@ -431,6 +433,8 @@ void startTests()
     printInt(42, intResult, "secondInnerStruct");
     intResult = accessInnerArray(42);
     printInt(42, intResult, "accessInnerArray");
+    intResult = assignNullStructProp();
+    printInt(42, intResult, "assignNullStructProp");
 
     int successCount = overallCount - failedCount;
     printf("\n\n%d tests of %d were successfull\n", successCount, overallCount);

--- a/testGeneratedCode/testCodeGenV1Prog.ll
+++ b/testGeneratedCode/testCodeGenV1Prog.ll
@@ -514,7 +514,7 @@ overFlowDoubleMixed(x:double, y:int, z:double, a:int, b:double, c:double, d:doub
     return x+y+z+a+b+c+d+e+f;
 }
 
-overFlowBoth(x:double, y:double, z:double, a:double, b:double, c:double, d:double, e:double, f:int, g:int, h:int, i:int, j:int, k:int, l:int, m:int, n:int): double
+ overFlowBoth(x:double, y:double, z:double, a:double, b:double, c:double, d:double, e:double, f:int, g:int, h:int, i:int, j:int, k:int, l:int, m:int, n:int): double
 {
     return x+y+z+a+b+c+d+e+f+g+h+i+j+k+l+m+n;
 }
@@ -641,4 +641,12 @@ accessInnerArray(x:int): int
     a.array[5] = 42;
 
     return a.array[5];
+}
+
+assignNullStructProp(): int
+{
+    a: iA = new iA();
+    a.array = null;
+
+    return 42;
 }


### PR DESCRIPTION
Resolves #80 . It is now possible to assign `null` to struct property which is of type `RefType`